### PR TITLE
Bump Higlass version to 1.9.1 and fix incompatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+
+- Add support for HiGlass `v1.9` 
+
 **v0.2.2**
 
 - Changed the size of the icon

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "d3-scale": "^1.0.7",
     "enzyme": "^3.6.0",
     "enzyme-adapter-react-16": "^1.6.0",
-    "higlass": "^1.6.2",
+    "higlass": "^1.9.1",
     "higlass-register": "^0.1.0",
     "i": "^0.3.6",
     "jasmine": "^2.99.0",

--- a/src/scripts/StackedBarTrack.js
+++ b/src/scripts/StackedBarTrack.js
@@ -72,6 +72,16 @@ const StackedBarTrack = (HGC, ...args) => {
 
       this.rescaleTiles();
     }
+
+    /**
+     * Prevent BarTracks draw method from having an effect
+     *
+     * @param tile
+     */
+    drawTile(tile) {
+
+    }
+
     /**
      * Draws exactly one tile.
      *


### PR DESCRIPTION
This PR bumps the version of Higlass to 1.9.1.

An empty `drawTile` method is introduced into the StackedBarTrack to prevent that BarTracks `drawTile` has an effect. This fixes an incompatibility of higlass-multivec with Higlass 1.9.